### PR TITLE
Fixed bug with names of db-derby archive

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,9 +151,9 @@ wget ftp://mirror.reverse.net/pub/apache/maven/maven-3/3.5.0/binaries/apache-mav
 wget http://mirror.stjschools.org/public/apache//db/derby/db-derby-10.13.1.1/db-derby-10.13.1.1-bin.tar.gz
 tar -xzvf apache-maven-3.5.0-bin.tar.gz
 sudo mkdir /opt/Apache
-sudo cp db-derby-10.13.1.1-bin.zip /opt/Apache/
+sudo cp db-derby-10.13.1.1-bin.tar.gz /opt/Apache/
 cd /opt/Apache/ 
-sudo unzip db-derby-10.13.1.1-bin.zip
+sudo tar -xzvf db-derby-10.13.1.1-bin.tar.gz
 ```
 3) Checkout the server code
 ```bash


### PR DESCRIPTION
The readme was mixing .zip and .tar.gz